### PR TITLE
Fix readme create venv command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 1. Clone This Project `git clone https://github.com/sajib1066/django-ecommerce.git`
 2. Go to Project Directory `cd django-ecommerce`
 3. Create a Virtual Environment `python -m venv venv`
-4. Activate Virtual Environment `source env/bin/activate`
+4. Activate Virtual Environment `source venv/bin/activate`
 5. Install Requirements Package `pip install -r requirements.txt`
 6. Migrate Database `python manage.py migrate`
 7. Create Super User `python manage.py createsuperuser`


### PR DESCRIPTION
Hey, I noticed that the command (from the README) for creating the virtual environment had a small typo.
Not a big deal if you've used venv before, as you can immediately figure out what's wrong.
However, it can be confusing to a newcomer trying to play around with this project, so it would be nice to have it fixed.

P.S. nice repo, I might make some more pull requests in the future.